### PR TITLE
Fix SPI1 slave select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# OS generated files #
+######################
+.DS_Store
+

--- a/hardware/atmega328pb/avr/libraries/SPI1/src/SPI1.cpp
+++ b/hardware/atmega328pb/avr/libraries/SPI1/src/SPI1.cpp
@@ -3,7 +3,7 @@
  * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
  * Copyright (c) 2014 by Matthijs Kooijman <matthijs@stdin.nl> (SPISettings AVR)
  * Copyright (c) 2014 by Andrew J. Kroll <xxxajk@gmail.com> (atomicity fixes)
- * Copyright (c) 2014 by Andre Moehl andre@ib-moehl.de (SPI1 Class, for Atmega328PB Support)
+ * Copyright (c) 2014 by Andre Moehl andre@ib-moehl.de (SPI1 Class, for ATmega328PB Support)
  * SPI Master library for arduino.
  *
  * This file is free software; you can redistribute it and/or modify
@@ -32,28 +32,28 @@ void SPI1Class::begin()
   uint8_t sreg = SREG;
   noInterrupts(); // Protect from a scheduler and prevent transactionBegin
   if (!initialized) {
-    // Set SS to high so a connected chip will be "deselected" by default
-    uint8_t port = digitalPinToPort(SS);
-    uint8_t bit = digitalPinToBitMask(SS);
+    // Set SS1 to high so a connected chip will be "deselected" by default
+    uint8_t port = digitalPinToPort(SS1);
+    uint8_t bit = digitalPinToBitMask(SS1);
     volatile uint8_t *reg = portModeRegister(port);
 
-    // if the SS pin is not already configured as an output
+    // if the SS1 pin is not already configured as an output
     // then set it high (to enable the internal pull-up resistor)
     if(!(*reg & bit)){
-      digitalWrite(SS, HIGH);
+      digitalWrite(SS1, HIGH);
     }
 
-    // When the SS pin is set as OUTPUT, it can be used as
+    // When the SS1 pin is set as OUTPUT, it can be used as
     // a general purpose output port (it doesn't influence
     // SPI operations).
-    pinMode(SS, OUTPUT);
+    pinMode(SS1, OUTPUT);
 
-    // Warning: if the SS pin ever becomes a LOW INPUT then SPI
+    // Warning: if the SS1 pin ever becomes a LOW INPUT then SPI
     // automatically switches to Slave, so the data direction of
-    // the SS pin MUST be kept as OUTPUT.
+    // the SS1 pin MUST be kept as OUTPUT.
 #if defined(__AVR_ATmega328PB__)
-    SPCR1 |= _BV(MSTR);
-    SPCR1 |= _BV(SPE);
+    SPCR1 |= _BV(MSTR1);
+    SPCR1 |= _BV(SPE1);
 #endif
 
     // Set direction register for SCK and MOSI pin.
@@ -80,7 +80,7 @@ void SPI1Class::end()
   if (!initialized)
   {
 #if defined(__AVR_ATmega328PB__)
-    SPCR0 &= ~_BV(SPE);
+    SPCR0 &= ~_BV(SPE1);
 #endif
     interruptMode = 0;
     #ifdef SPI_TRANSACTION_MISMATCH_LED

--- a/hardware/atmega328pb/avr/libraries/SPI1/src/SPI1.cpp
+++ b/hardware/atmega328pb/avr/libraries/SPI1/src/SPI1.cpp
@@ -3,7 +3,7 @@
  * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
  * Copyright (c) 2014 by Matthijs Kooijman <matthijs@stdin.nl> (SPISettings AVR)
  * Copyright (c) 2014 by Andrew J. Kroll <xxxajk@gmail.com> (atomicity fixes)
- * Copyright (c) 2014 by Andre Moehl andre@ib-moehl.de (SPI1 Class, for Atmega3258PB Support)
+ * Copyright (c) 2014 by Andre Moehl andre@ib-moehl.de (SPI1 Class, for Atmega328PB Support)
  * SPI Master library for arduino.
  *
  * This file is free software; you can redistribute it and/or modify
@@ -69,7 +69,7 @@ void SPI1Class::begin()
   SREG = sreg;
 }
 
-void SPI1Class::end() 
+void SPI1Class::end()
 {
   uint8_t sreg = SREG;
   noInterrupts(); // Protect from a scheduler and prevent transactionBegin
@@ -77,7 +77,7 @@ void SPI1Class::end()
   if (initialized)
     initialized--;
   // If there are no more references disable SPI
-  if (!initialized) 
+  if (!initialized)
   {
 #if defined(__AVR_ATmega328PB__)
     SPCR0 &= ~_BV(SPE);

--- a/hardware/atmega328pb/avr/libraries/SPI1/src/SPI1.h
+++ b/hardware/atmega328pb/avr/libraries/SPI1/src/SPI1.h
@@ -21,29 +21,29 @@
 /* SPI 1 Class *****************************************************/
 class SPI1Settings {
 public:
-  	SPI1Settings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) 
+  	SPI1Settings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)
 	{
-    	if (__builtin_constant_p(clock)) 
+    	if (__builtin_constant_p(clock))
 		{
       		init_AlwaysInline(clock, bitOrder, dataMode);
-    	} else 
+    	} else
 		{
       		init_MightInline(clock, bitOrder, dataMode);
     	}
   	}
-  
-	SPI1Settings() 
+
+	SPI1Settings()
 	{
     	init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0);
   	}
 
 private:
-  	void init_MightInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) 
+  	void init_MightInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)
 	{
     	init_AlwaysInline(clock, bitOrder, dataMode);
   	}
-  	
-	void init_AlwaysInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) __attribute__((__always_inline__)) 
+
+	void init_AlwaysInline(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) __attribute__((__always_inline__))
 	{
 		// Clock settings are defined as follows. Note that this shows SPI2X
 		// inverted, so the bits form increasing numbers. Also note that
@@ -111,7 +111,7 @@ private:
   friend class SPI1Class;
 };
 
-class SPI1Class 
+class SPI1Class
 {
 public:
   // Initialize the SPI library
@@ -182,7 +182,7 @@ public:
 #endif
   }
 
-  inline static uint16_t transfer16(uint16_t data) 
+  inline static uint16_t transfer16(uint16_t data)
   {
     union { uint16_t val; struct { uint8_t lsb; uint8_t msb; }; } in, out;
     in.val = data;
@@ -210,7 +210,7 @@ public:
     return out.val;
   }
 
-  inline static void transfer(void *buf, size_t count) 
+  inline static void transfer(void *buf, size_t count)
   {
     if (count == 0) return;
     uint8_t *p = (uint8_t *)buf;
@@ -231,7 +231,7 @@ public:
 
   // After performing a group of transfers and releasing the chip select
   // signal, this function allows others to access the SPI bus
-  inline static void endTransaction(void) 
+  inline static void endTransaction(void)
   {
     #ifdef SPI_TRANSACTION_MISMATCH_LED
     if (!inTransactionFlag) {
@@ -263,7 +263,7 @@ public:
 
   // This function is deprecated.  New applications should use
   // beginTransaction() to configure SPI settings.
-  inline static void setBitOrder(uint8_t bitOrder) 
+  inline static void setBitOrder(uint8_t bitOrder)
 {
 #if defined(__AVR_ATmega328PB__)
     if (bitOrder == LSBFIRST) SPCR1 |= _BV(DORD);

--- a/hardware/atmega328pb/avr/libraries/SPI1/src/SPI1.h
+++ b/hardware/atmega328pb/avr/libraries/SPI1/src/SPI1.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
  * Copyright (c) 2014 by Matthijs Kooijman <matthijs@stdin.nl> (SPISettings AVR)
  * Copyright (c) 2014 by Andrew J. Kroll <xxxajk@gmail.com> (atomicity fixes)
- * Copyright (c) 2014 by Andre Moehl andre@ib-moehl.de (SPI1 Class, for Atmega3258PB Support)
+ * Copyright (c) 2014 by Andre Moehl andre@ib-moehl.de (SPI1 Class, for ATmega328PB Support)
  * SPI Master library for arduino.
  *
  * This file is free software; you can redistribute it and/or modify
@@ -102,7 +102,7 @@ private:
 
     // Pack into the SPI1Settings class
 #if defined(__AVR_ATmega328PB__)
-   		spcr = _BV(SPE) | _BV(MSTR) | ((bitOrder == LSBFIRST) ? _BV(DORD) : 0) |
+    spcr = _BV(SPE1) | _BV(MSTR1) | ((bitOrder == LSBFIRST) ? _BV(DORD1) : 0) |
       (dataMode & SPI_MODE_MASK) | ((clockDiv >> 1) & SPI_CLOCK_MASK);
 #endif
   }
@@ -187,23 +187,23 @@ public:
     union { uint16_t val; struct { uint8_t lsb; uint8_t msb; }; } in, out;
     in.val = data;
 #if defined(__AVR_ATmega328PB__)
-    if (!(SPCR1 & _BV(DORD))) {
+    if (!(SPCR1 & _BV(DORD1))) {
       SPDR1 = in.msb;
       asm volatile("nop"); // See transfer(uint8_t) function
-      while (!(SPSR1 & _BV(SPIF))) ;
+      while (!(SPSR1 & _BV(SPIF1))) ;
       out.msb = SPDR1;
       SPDR1 = in.lsb;
       asm volatile("nop");
-      while (!(SPSR1 & _BV(SPIF))) ;
+      while (!(SPSR1 & _BV(SPIF1))) ;
       out.lsb = SPDR1;
     } else {
       SPDR1 = in.lsb;
       asm volatile("nop");
-      while (!(SPSR1 & _BV(SPIF))) ;
+      while (!(SPSR1 & _BV(SPIF1))) ;
       out.lsb = SPDR1;
       SPDR1 = in.msb;
       asm volatile("nop");
-      while (!(SPSR1 & _BV(SPIF))) ;
+      while (!(SPSR1 & _BV(SPIF1))) ;
       out.msb = SPDR1;
     }
 #endif
@@ -218,12 +218,12 @@ public:
     SPDR1 = *p;
     while (--count > 0) {
       uint8_t out = *(p + 1);
-      while (!(SPSR1 & _BV(SPIF))) ;
+      while (!(SPSR1 & _BV(SPIF1))) ;
       uint8_t in = SPDR1;
       SPDR1 = out;
       *p++ = in;
     }
-    while (!(SPSR1 & _BV(SPIF))) ;
+    while (!(SPSR1 & _BV(SPIF1))) ;
     *p = SPDR1;
 
 #endif
@@ -266,8 +266,8 @@ public:
   inline static void setBitOrder(uint8_t bitOrder)
 {
 #if defined(__AVR_ATmega328PB__)
-    if (bitOrder == LSBFIRST) SPCR1 |= _BV(DORD);
-    else SPCR1 &= ~(_BV(DORD));
+    if (bitOrder == LSBFIRST) SPCR1 |= _BV(DORD1);
+    else SPCR1 &= ~(_BV(DORD1));
 #endif
   }
 
@@ -276,8 +276,8 @@ public:
   // polls the hardware flag which is automatically cleared as the
   // AVR responds to SPI's interrupt
 #if defined(__AVR_ATmega328PB__)
-  inline static void attachInterrupt() { SPCR1 |= _BV(SPIE	); }
-  inline static void detachInterrupt() { SPCR1 &= ~_BV(SPIE); }
+  inline static void attachInterrupt() { SPCR1 |= _BV(SPIE1); }
+  inline static void detachInterrupt() { SPCR1 &= ~_BV(SPIE1); }
 #endif
 
 private:


### PR DESCRIPTION
Besides some cosmetic changes, this pull request fixes the issue that for SPI1 the wrong slave select is set to output, namely SS0 instead of SS1. As a result SPI1 will easily switch to slave mode and stops generating the clock pulses needed for a master SPI communication.